### PR TITLE
Update to Guzzle ~6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "fabpot/php-cs-fixer": "~1.6",
-        "guzzlehttp/guzzle": "~5.0"
+        "guzzlehttp/guzzle": "~6.0"
     },
     "suggest": {
         "guzzlehttp/guzzle": "For Guzzle constraints"

--- a/src/PhpUnit/GuzzleAssertsTrait.php
+++ b/src/PhpUnit/GuzzleAssertsTrait.php
@@ -3,8 +3,9 @@
 namespace FR3D\SwaggerAssertions\PhpUnit;
 
 use FR3D\SwaggerAssertions\SchemaManager;
-use GuzzleHttp\Message\RequestInterface;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use PHPUnit_Framework_Assert as Assert;
 
 /**
  * Facade functions for interact with Guzzle constraints.
@@ -29,8 +30,11 @@ trait GuzzleAssertsTrait
         $httpMethod,
         $message = ''
     ) {
+        $contentTypeHeader = $response->getHeader('Content-Type');
+        Assert::assertNotEmpty($contentTypeHeader);
+
         $this->assertResponseMediaTypeMatch(
-            $response->getHeader('Content-Type'),
+            $contentTypeHeader[0],
             $schemaManager,
             $path,
             $httpMethod,
@@ -53,7 +57,7 @@ trait GuzzleAssertsTrait
         );
 
         $this->assertResponseBodyMatch(
-            $responseBody = $response->json(['object' => true]),
+            $responseBody = json_decode($response->getBody()),
             $schemaManager,
             $path,
             $httpMethod,
@@ -76,6 +80,6 @@ trait GuzzleAssertsTrait
         SchemaManager $schemaManager,
         $message = ''
     ) {
-        $this->assertResponseMatch($response, $schemaManager, $request->getPath(), $request->getMethod(), $message);
+        $this->assertResponseMatch($response, $schemaManager, $request->getUri()->getPath(), $request->getMethod(), $message);
     }
 }

--- a/tests/PhpUnit/GuzzleAssertsTraitTest.php
+++ b/tests/PhpUnit/GuzzleAssertsTraitTest.php
@@ -4,9 +4,9 @@ namespace FR3D\SwaggerAssertionsTest\PhpUnit;
 
 use FR3D\SwaggerAssertions\PhpUnit\GuzzleAssertsTrait;
 use FR3D\SwaggerAssertions\SchemaManager;
-use GuzzleHttp\Message\Request;
-use GuzzleHttp\Message\Response;
-use GuzzleHttp\Stream\Stream;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7;
 use PHPUnit_Framework_ExpectationFailedException as ExpectationFailedException;
 use PHPUnit_Framework_TestCase as TestCase;
 
@@ -27,7 +27,7 @@ class GuzzleAssertsTraitTest extends TestCase
     public function testAssertResponseMatch()
     {
         $response = $this->getValidResponseBody();
-        $response = new Response(200, $this->getValidHeaders(), Stream::factory($response));
+        $response = new Response(200, $this->getValidHeaders(), Psr7\stream_for($response));
 
         self::assertResponseMatch($response, $this->schemaManager, '/api/pets', 'get');
     }
@@ -35,7 +35,7 @@ class GuzzleAssertsTraitTest extends TestCase
     public function testAssertResponseAndRequestMatch()
     {
         $response = $this->getValidResponseBody();
-        $response = new Response(200, $this->getValidHeaders(), Stream::factory($response));
+        $response = new Response(200, $this->getValidHeaders(), Psr7\stream_for($response));
         $request = new Request('GET', 'http://example.com/api/pets');
 
         self::assertResponseAndRequestMatch($response, $request, $this->schemaManager);
@@ -50,7 +50,7 @@ class GuzzleAssertsTraitTest extends TestCase
   }
 ]
 JSON;
-        $response = new Response(200, $this->getValidHeaders(), Stream::factory($response));
+        $response = new Response(200, $this->getValidHeaders(), Psr7\stream_for($response));
 
         try {
             self::assertResponseMatch($response, $this->schemaManager, '/api/pets', 'get');
@@ -71,7 +71,7 @@ EOF
     public function testAssertResponseMediaTypeDoesNotMatch()
     {
         $response = $this->getValidResponseBody();
-        $response = new Response(200, ['Content-Type' => 'application/pdf; charset=utf-8'], Stream::factory($response));
+        $response = new Response(200, ['Content-Type' => 'application/pdf; charset=utf-8'], Psr7\stream_for($response));
 
         try {
             self::assertResponseMatch($response, $this->schemaManager, '/api/pets', 'get');
@@ -91,7 +91,7 @@ EOF
             // 'ETag' => '123', // Removed intentional
         ];
 
-        $response = new Response(200, $headers, Stream::factory($this->getValidResponseBody()));
+        $response = new Response(200, $headers, Psr7\stream_for($this->getValidResponseBody()));
 
         try {
             self::assertResponseMatch($response, $this->schemaManager, '/api/pets', 'get');


### PR DESCRIPTION
Quick changes I made to update to Guzzle ~6, feel free to close if you'd prefer to keep ~5 as Guzzle 6 requires PHP 5.5+.

The the exception of incompatible PHP 5.4, the failing tests are fixed in #3