### PR TITLE
Compare headers in a case insensitive way

### DIFF
--- a/src/PhpUnit/ResponseHeadersConstraint.php
+++ b/src/PhpUnit/ResponseHeadersConstraint.php
@@ -84,11 +84,15 @@ class ResponseHeadersConstraint extends Constraint
     protected function getValidator($headers)
     {
         $schema = new \stdClass();
-        $schema->properties = $this->schemaManager->getResponseHeaders($this->path, $this->httpMethod, $this->httpCode);
+        $headers = (object) array_change_key_case((array) $headers, CASE_LOWER);
+
+        $properties = $this->schemaManager->getResponseHeaders($this->path, $this->httpMethod, $this->httpCode);
+
+        $schema->properties = (object) array_change_key_case((array) $properties, CASE_LOWER);
         $schema->required = array_keys((array) $schema->properties);
 
         $validator = new Validator();
-        $validator->check((object) $headers, $schema);
+        $validator->check($headers, $schema);
 
         return $validator;
     }

--- a/tests/PhpUnit/GuzzleAssertsTraitTest.php
+++ b/tests/PhpUnit/GuzzleAssertsTraitTest.php
@@ -100,7 +100,7 @@ EOF
             self::assertEquals(
                 <<<EOF
 Failed asserting that {"Content-Type":"application\/json"} is valid.
-[ETag] The property ETag is required
+[etag] The property etag is required
 
 EOF
                 ,

--- a/tests/PhpUnit/Psr7AssertsTraitTest.php
+++ b/tests/PhpUnit/Psr7AssertsTraitTest.php
@@ -103,7 +103,7 @@ EOF
             self::assertEquals(
                 <<<EOF
 Failed asserting that {"Content-Type":"application\/json"} is valid.
-[ETag] The property ETag is required
+[etag] The property etag is required
 
 EOF
                 ,

--- a/tests/PhpUnit/ResponseHeadersConstraintTest.php
+++ b/tests/PhpUnit/ResponseHeadersConstraintTest.php
@@ -58,7 +58,7 @@ class ResponseHeadersConstraintTest extends TestCase
             self::assertEquals(
                 <<<EOF
 Failed asserting that {"Content-Type":"application\/json"} is valid.
-[ETag] The property ETag is required
+[etag] The property etag is required
 
 EOF
                 ,

--- a/tests/PhpUnit/ResponseHeadersConstraintTest.php
+++ b/tests/PhpUnit/ResponseHeadersConstraintTest.php
@@ -42,6 +42,16 @@ class ResponseHeadersConstraintTest extends TestCase
         self::assertTrue($this->constraint->evaluate($headers, '', true), $this->constraint->evaluate($headers));
     }
 
+    public function testCaseInsensitiveValidHeaders()
+    {
+        $headers = [
+            'Content-Type' => 'application/json',
+            'etag' => '123',
+        ];
+
+        self::assertTrue($this->constraint->evaluate($headers, '', true), $this->constraint->evaluate($headers));
+    }
+
     public function testInvalidHeaderType()
     {
         $headers = [


### PR DESCRIPTION
HTTP headers are case insensitive (http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2). This change converts the input headers and the schema headers to lowercase before comparing them with the Validator.