### PR TITLE
Add a trait supporting Symfony HttpFoundation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,12 @@
     "require-dev": {
         "fabpot/php-cs-fixer": "~1.6",
         "guzzlehttp/guzzle": "~5.0",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0",
+        "symfony/http-foundation": "^2.7"
     },
     "suggest": {
-        "guzzlehttp/guzzle": "For Guzzle constraints"
+        "guzzlehttp/guzzle": "For Guzzle constraints",
+        "symfony/http-foundation": "For Symfony constraints"
     },
     "autoload": {
         "psr-4": {

--- a/src/PhpUnit/SymfonyAssertsTrait.php
+++ b/src/PhpUnit/SymfonyAssertsTrait.php
@@ -1,0 +1,83 @@
+<?php
+
+
+namespace FR3D\SwaggerAssertions\PhpUnit;
+
+use FR3D\SwaggerAssertions\SchemaManager;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Facade functions for interacting with Symfony/HttpFoundation constraints.
+ */
+trait SymfonyAssertsTrait
+{
+    use AssertsTrait;
+
+    /**
+     * Asserts response match with the response schema.
+     *
+     * @param Response $response
+     * @param SchemaManager $schemaManager
+     * @param string $path percent-encoded path used on the request.
+     * @param string $httpMethod
+     * @param string $message
+     */
+    public function assertResponseMatch(
+        Response $response,
+        SchemaManager $schemaManager,
+        $path,
+        $httpMethod,
+        $message = ''
+    ) {
+        $this->assertResponseMediaTypeMatch(
+            $response->headers->get('Content-Type'),
+            $schemaManager,
+            $path,
+            $httpMethod,
+            $message
+        );
+
+        $httpCode = $response->getStatusCode();
+
+        $headers = $response->headers->all();
+        foreach ($headers as &$value) {
+            $value = implode(', ', $value);
+        }
+
+        $this->assertResponseHeadersMatch(
+            $headers,
+            $schemaManager,
+            $path,
+            $httpMethod,
+            $httpCode,
+            $message
+        );
+
+        $this->assertResponseBodyMatch(
+            json_decode($response->getContent()),
+            $schemaManager,
+            $path,
+            $httpMethod,
+            $httpCode,
+            $message
+        );
+    }
+
+    /**
+     * Asserts response match with the response schema.
+     *
+     * @param Response $response
+     * @param Request $request
+     * @param SchemaManager $schemaManager
+     * @param string $message
+     */
+    public function assertResponseAndRequestMatch(
+        Response $response,
+        Request $request,
+        SchemaManager $schemaManager,
+        $message = ''
+    ) {
+        $this->assertResponseMatch($response, $schemaManager, $request->getRequestUri(), $request->getMethod(), $message);
+    }
+}

--- a/tests/PhpUnit/SymfonyAssertsTraitTest.php
+++ b/tests/PhpUnit/SymfonyAssertsTraitTest.php
@@ -1,0 +1,156 @@
+<?php
+
+
+namespace FR3D\SwaggerAssertionsTest\PhpUnit;
+
+use FR3D\SwaggerAssertions\SchemaManager;
+use PHPUnit_Framework_ExpectationFailedException as ExpectationFailedException;
+use PHPUnit_Framework_TestCase as TestCase;
+use FR3D\SwaggerAssertions\PhpUnit\SymfonyAssertsTrait;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SymfonyAssertsTraitTest extends TestCase
+{
+
+    use SymfonyAssertsTrait;
+
+    /**
+     * @var SchemaManager
+     */
+    protected $schemaManager;
+
+    protected function setUp()
+    {
+        $this->schemaManager = new SchemaManager('file://' . __DIR__ . '/../fixture/petstore-with-external-docs.json');
+    }
+
+    public function testAssertResponseMatch()
+    {
+        $response = $this->createResponse(200, $this->getValidHeaders(), $this->getValidResponseBody());
+
+        self::assertResponseMatch($response, $this->schemaManager, '/api/pets', 'get');
+    }
+
+    public function testAssertResponseAndRequestMatch()
+    {
+        $response = $this->createResponse(200, $this->getValidHeaders(), $this->getValidResponseBody());
+        $request = $this->createReqyest('GET', '/api/pets');
+
+        self::assertResponseAndRequestMatch($response, $request, $this->schemaManager);
+    }
+
+    public function testAssertResponseBodyDoesNotMatch()
+    {
+        $response = <<<JSON
+[
+  {
+    "id": 123456789
+  }
+]
+JSON;
+        $response = $this->createResponse(200, $this->getValidHeaders(), $response);
+
+        try {
+            self::assertResponseMatch($response, $this->schemaManager, '/api/pets', 'get');
+            self::fail('Expected ExpectationFailedException to be thrown');
+        } catch (ExpectationFailedException $e) {
+            self::assertRegExp(
+                sprintf('/^Failed asserting that \[{.+}\] is valid.\\n\[%1$s\] The property %1$s is required\\n$/i', 'name'),
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function testAssertResponseMediaTypeDoesNotMatch()
+    {
+        $response = $this->createResponse(
+            200,
+            ['Content-Type' => ['application/pdf; charset=utf-8']],
+            $this->getValidResponseBody()
+        );
+
+        try {
+            self::assertResponseMatch($response, $this->schemaManager, '/api/pets', 'get');
+            self::fail('Expected ExpectationFailedException to be thrown');
+        } catch (ExpectationFailedException $e) {
+            self::assertEquals(
+                "Failed asserting that 'application/pdf' is an allowed media type (application/json, application/xml, text/xml, text/html).",
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function testAssertResponseHeaderDoesNotMatch()
+    {
+        $headers = [
+            'Content-Type' => ['application/json'],
+            // 'ETag' => ['123'], // Removed intentional
+        ];
+
+        $response = $this->createResponse(200, $headers, $this->getValidResponseBody());
+
+        try {
+            self::assertResponseMatch($response, $this->schemaManager, '/api/pets', 'get');
+            self::fail('Expected ExpectationFailedException to be thrown');
+        } catch (ExpectationFailedException $e) {
+            self::assertRegExp(
+                sprintf('/^Failed asserting that {.+} is valid.\\n\[%1$s\] The property %1$s is required\\n$/i', 'etag'),
+                $e->getMessage()
+            );
+        }
+    }
+
+    /**
+     * @return string
+     */
+    protected function getValidResponseBody()
+    {
+        return <<<JSON
+[
+  {
+    "id": 123456789,
+    "name": "foo"
+  }
+]
+JSON;
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getValidHeaders()
+    {
+        return [
+            'Content-Type' =>
+                'application/json'
+            ,
+            'ETag' =>
+                '123'
+            ,
+        ];
+    }
+
+    /**
+     * @param string $method
+     * @param string $path
+     *
+     * @return Request
+     */
+    protected function createReqyest($method, $path)
+    {
+        return Request::create($path, $method);
+    }
+
+    /**
+     * @param int $statusCode
+     * @param array $headers
+     * @param string $body
+     *
+     * @return Response
+     */
+    protected function createResponse($statusCode, array $headers, $body)
+    {
+        return new Response($body, $statusCode, $headers);
+    }
+}


### PR DESCRIPTION
I delayed sending this PR because in my own project I converted my Symfony requests to PSR7 and used the existing trait. 

However, this may be useful for some people. 

For now, this branch requires json-schema dependency `>=1.4.2 <1.5` which exists on your master branch.