### PR TITLE
Clone query parameters before altering them

### DIFF
--- a/src/PhpUnit/RequestQueryConstraint.php
+++ b/src/PhpUnit/RequestQueryConstraint.php
@@ -15,6 +15,8 @@ class RequestQueryConstraint extends JsonSchemaConstraint
         $normalizedSchema = new \stdClass();
         $normalizedSchema->required = [];
         foreach ($queryParameters as $queryParameter) {
+            $queryParameter = clone $queryParameter;
+
             if (!isset($queryParameter->name)) {
                 // @codeCoverageIgnoreStart
                 throw new \DomainException('Expected missing name field');

--- a/tests/PhpUnit/RequestQueryConstraintTest.php
+++ b/tests/PhpUnit/RequestQueryConstraintTest.php
@@ -89,4 +89,15 @@ EOF
             );
         }
     }
+
+    public function testConstructorDoesNotAlterParameters()
+    {
+        $source = '[{"name":"tags","in":"query","description":"tags to filter by","required":false,"type":"array","items":{"type":"string"},"collectionFormat":"csv"},{"name":"limit","in":"query","description":"maximum number of results to return","required":true,"type":"integer","format":"int32"}]';
+        $schema = json_decode($source);
+        $expected = json_decode($source);
+
+        new RequestQueryConstraint($schema);
+
+        self::assertEquals($expected, $schema);
+    }
 }


### PR DESCRIPTION
Clone query parameters before altering them because otherwise we will remove properties from the base schema object