### PR TITLE
Update the UriTemplate version to include fix for URL extraction for file extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">= 7.0",
         "justinrainbow/json-schema": "^2.0.1",
         "phpunit/phpunit": "^6.0",
-        "rize/uri-template": "^0.3.0",
+        "rize/uri-template": "^0.3.1",
         "zendframework/zend-http": "2.5 - 3"
     },
     "require-dev": {


### PR DESCRIPTION
After a discussion and fix on the 3rd party UriTemplate library here: https://github.com/rize/UriTemplate/issues/8

I'd like to update the SwaggerAsserion so I could use it in our project