### PR TITLE
Add support for shared Path Item parameters

### DIFF
--- a/tests/SchemaManagerTest.php
+++ b/tests/SchemaManagerTest.php
@@ -138,6 +138,33 @@ class SchemaManagerTest extends TestCase
     }
 
     /**
+     * @dataProvider requestParameters
+     */
+    public function testGetRequestParameters($path, $method, $expectedParameters)
+    {
+        $parameters = $this->schemaManager->getRequestParameters($path, $method);
+
+        self::assertEquals($expectedParameters, json_encode($parameters));
+    }
+
+    public function requestParameters()
+    {
+        $pets_id_shared_parameters = '[{"name":"id","in":"path","description":"ID of pet to fetch","required":true,"type":"integer","format":"int64"}';
+        $pets_id_patch_parameters = $pets_id_shared_parameters . ',{"name":"X-Required-Header","in":"header","description":"Required header","required":true,"type":"string"},{"name":"X-Optional-Header","in":"header","description":"Optional header","type":"string"},{"name":"pet","in":"body","description":"Pet to update","required":true,"schema":{"type":"object","allOf":[{"type":"object","required":["id","name"],"externalDocs":{"description":"find more info here","url":"https:\/\/swagger.io\/about"},"properties":{"id":{"type":"integer","format":"int64"},"name":{"type":"string"},"tag":{"type":"string"}}},{"required":["id"],"properties":{"id":{"type":"integer","format":"int64"}}}]}}]';
+        $pets_id_delete_parameter = '[{"name":"id","in":"path","description":"Override the shared ID parameter","required":true,"type":"integer","format":"int64"}]';
+
+        $dataSet = [
+            // Description => [path, method, expectedParameters]
+            'without parameters' => ['/food', 'get', '[]'],
+            'with a shared parameter and operation parameters' => ['/pets/{id}', 'patch', $pets_id_patch_parameters],
+            'with a operation parameter that overrides a shared parameter' => ['/pets/{id}', 'delete', $pets_id_delete_parameter],
+            'with only a shared parameter' => ['/pets/{id}', 'get', $pets_id_shared_parameters . ']'],
+        ];
+
+        return $dataSet;
+    }
+
+    /**
      * @dataProvider requestHeadersParameters
      */
     public function testGetRequestHeadersParameters($path, $method, $expectedParameters)

--- a/tests/fixture/petstore-with-external-docs.json
+++ b/tests/fixture/petstore-with-external-docs.json
@@ -148,6 +148,16 @@
       }
     },
     "/pets/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "ID of pet to fetch",
+          "required": true,
+          "type": "integer",
+          "format": "int64"
+        }
+      ],
       "patch": {
         "description": "Creates a new pet in the store.  Duplicates are allowed",
         "operationId": "updatePet",
@@ -159,14 +169,6 @@
           "application/json"
         ],
         "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "ID of pet to fetch",
-            "required": true,
-            "type": "integer",
-            "format": "int64"
-          },
           {
             "$ref": "#/parameters/required_header"
           },
@@ -213,16 +215,6 @@
           "text/xml",
           "text/html"
         ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "ID of pet to fetch",
-            "required": true,
-            "type": "integer",
-            "format": "int64"
-          }
-        ],
         "responses": {
           "200": {
             "description": "pet response",
@@ -245,7 +237,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "ID of pet to delete",
+            "description": "Override the shared ID parameter",
             "required": true,
             "type": "integer",
             "format": "int64"


### PR DESCRIPTION
This adds support for parameters at the Path Item level, which are shared by all operations described under the path per the Swagger 2.0 spec. Operation parameters can override these.
Link to spec: http://swagger.io/specification/#fixed-fields-33