### PR TITLE
Add a test for PSR7 query type checking

### DIFF
--- a/tests/PhpUnit/Psr7AssertsTraitTest.php
+++ b/tests/PhpUnit/Psr7AssertsTraitTest.php
@@ -181,6 +181,21 @@ EOF
         }
     }
 
+    public function testAssertRequestQueryTypeCheck()
+    {
+        $headers = [
+            'Content-Type' => ['application/json'],
+            'X-Optional-Header' => ['any'],
+        ];
+        $query = [
+            'page' => 1,
+            'limit' => 1000,
+        ];
+        $request = $this->createMockRequest('GET', '/api/pets', $headers, $this->getValidRequestBody(), $query);
+
+        self::assertRequestMatch($request, $this->schemaManager);
+    }
+
     public function testAssertRequestHeaderDoesNotMatch()
     {
         $headers = [


### PR DESCRIPTION
The test is failing, but I don't think it should.

Here is the error message:

> Failed asserting that {"page":"1","limit":"1000"} is a valid request query.
> [limit] String value found, but an integer is required

Edit : I made this PR just to demonstrate issue #30 