### PR TITLE
Fix side effects in RequestHeadersConstraint

### DIFF
--- a/src/PhpUnit/RequestHeadersConstraint.php
+++ b/src/PhpUnit/RequestHeadersConstraint.php
@@ -24,6 +24,8 @@ class RequestHeadersConstraint extends JsonSchemaConstraint
                 // @codeCoverageIgnoreEnd
             }
 
+            $headerParameter = clone $headerParameter;
+
             $normalizedName = strtolower($headerParameter->name);
             unset($headerParameter->name);
 

--- a/tests/PhpUnit/RequestHeadersConstraintTest.php
+++ b/tests/PhpUnit/RequestHeadersConstraintTest.php
@@ -17,11 +17,11 @@ class RequestHeadersConstraintTest extends TestCase
      * @var Constraint
      */
     protected $constraint;
+    const TEST_SCHEMA = '[{"name":"X-Required-Header","in":"header","description":"Required header","required":true,"type":"string"},{"name":"X-Optional-Header","in":"header","description":"Optional header","type":"string"}]';
 
     protected function setUp()
     {
-        $schema = '[{"name":"X-Required-Header","in":"header","description":"Required header","required":true,"type":"string"},{"name":"X-Optional-Header","in":"header","description":"Optional header","type":"string"}]';
-        $schema = json_decode($schema);
+        $schema = json_decode(self::TEST_SCHEMA);
 
         $this->constraint = new RequestHeadersConstraint($schema, new Validator());
     }
@@ -72,5 +72,14 @@ EOF
                 TestFailure::exceptionToString($e)
             );
         }
+    }
+
+    public function testSchemaUnchanged()
+    {
+        $schema = json_decode(self::TEST_SCHEMA);
+        new RequestHeadersConstraint($schema, new Validator());
+
+        // Make sure there were no side effects ($schema should be unchanged)
+        self::assertEquals($schema, json_decode(self::TEST_SCHEMA));
     }
 }


### PR DESCRIPTION
The constructor in RequestHeadersConstraint takes in a array of header parameters from the Swagger definition and modifies them by calling `unset($headerParameter->name);` and `unset($headerParameter->required);`. This changes the definition and can cause subsequent assertions to fail.

The RequestQueryConstraint constructor calls `$queryParameter = clone $queryParameter;` to prevent this, so I just did the same here.