### PR TITLE
Do not validate Media-Type when response is empty

### DIFF
--- a/src/PhpUnit/SymfonyAssertsTrait.php
+++ b/src/PhpUnit/SymfonyAssertsTrait.php
@@ -26,13 +26,15 @@ trait SymfonyAssertsTrait
         string $httpMethod,
         string $message = ''
     ) {
-        $this->assertResponseMediaTypeMatch(
-            $response->headers->get('Content-Type'),
-            $schemaManager,
-            $path,
-            $httpMethod,
-            $message
-        );
+        if (!empty((string) $response->getContent())) {
+            $this->assertResponseMediaTypeMatch(
+                $response->headers->get('Content-Type'),
+                $schemaManager,
+                $path,
+                $httpMethod,
+                $message
+            );
+        }
 
         $httpCode = $response->getStatusCode();
         $headers = $this->inlineHeaders($response->headers->all());


### PR DESCRIPTION
According to RFC 2616: 
- Informational Response (100 <= statusCode < 200) 
- Empty Response (statusCode is 204 or 304) 

should not contain `Content-Type` header

Symfony framework v.3.3.4 removes this header from the response and therefore assertions are failing