### PR TITLE
Add support for justinrainbow/json-schema:^5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "homepage": "https://github.com/Maks3w/SwaggerAssertions",
     "require": {
         "php": ">= 7.0",
-        "justinrainbow/json-schema": "^2.0.1",
         "phpunit/phpunit": "^6.0",
+        "justinrainbow/json-schema": "^5.0",
         "rize/uri-template": "^0.3.0",
         "zendframework/zend-http": "2.5 - 3"
     },

--- a/src/JsonSchema/RefResolver.php
+++ b/src/JsonSchema/RefResolver.php
@@ -1,0 +1,187 @@
+<?php
+
+/*
+ * This file is part of the JsonSchema package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FR3D\SwaggerAssertions\JsonSchema;
+
+use JsonSchema\Exception\UnresolvableJsonPointerException;
+use JsonSchema\Iterator\ObjectIterator;
+use JsonSchema\Entity\JsonPointer;
+use JsonSchema\UriResolverInterface;
+use JsonSchema\UriRetrieverInterface;
+
+/**
+ * Take in a source uri to locate a JSON schema and retrieve it and take care of all $ref references.
+ * Try to update the resolved schema which looks like a tree, but can be a graph. (so cyclic schema's are allowed).
+ * This way the current validator does not need to be changed and can work as well with the updated schema.
+ *
+ * @package JsonSchema
+ * @author Joost Nijhuis <jnijhuis81@gmail.com>
+ * @author Rik Jansen <rikjansen@gmail.com>
+ */
+class RefResolver
+{
+    /** @var UriRetrieverInterface */
+    private $uriRetriever;
+
+    /** @var UriResolverInterface */
+    private $uriResolver;
+
+    /**
+     * @param UriRetrieverInterface $retriever
+     * @param UriResolverInterface $uriResolver
+     */
+    public function __construct(UriRetrieverInterface $retriever, UriResolverInterface $uriResolver)
+    {
+        $this->uriRetriever = $retriever;
+        $this->uriResolver = $uriResolver;
+    }
+
+    /**
+     * Resolves all schema and all $ref references for the give $sourceUri. Recurse through the object to resolve
+     * references of any child schemas and return the schema.
+     *
+     * @param string $sourceUri URI where this schema was located
+     * @return object
+     */
+    public function resolve($sourceUri)
+    {
+        return $this->resolveCached($sourceUri, array());
+    }
+
+    /**
+     * @param string $sourceUri URI where this schema was located
+     * @param array $paths
+     * @return object
+     */
+    private function resolveCached($sourceUri, array $paths)
+    {
+        $jsonPointer = new JsonPointer($sourceUri);
+
+        $fileName = $jsonPointer->getFilename();
+        if (!array_key_exists($fileName, $paths)) {
+            $schema = $this->uriRetriever->retrieve($jsonPointer->getFilename());
+            $paths[$jsonPointer->getFilename()] = $schema;
+            $this->resolveSchemas($schema, $jsonPointer->getFilename(), $paths);
+        }
+        $schema = $paths[$fileName];
+
+        return $this->getRefSchema($jsonPointer, $schema);
+    }
+
+    /**
+     * Recursive resolve schema by traversing through al nodes
+     *
+     * @param object $unresolvedSchema
+     * @param string $fileName
+     * @param array $paths
+     */
+    private function resolveSchemas($unresolvedSchema, $fileName, array $paths)
+    {
+        $objectIterator = new ObjectIterator($unresolvedSchema);
+        foreach ($objectIterator as $toResolveSchema) {
+            if (property_exists($toResolveSchema, '$ref') && is_string($toResolveSchema->{'$ref'})) {
+                $jsonPointer = new JsonPointer($this->uriResolver->resolve($toResolveSchema->{'$ref'}, $fileName));
+                $refSchema = $this->resolveCached((string) $jsonPointer, $paths);
+                $this->unionSchemas($refSchema, $toResolveSchema, $fileName, $paths);
+            }
+        }
+    }
+
+    /**
+     * @param JsonPointer $jsonPointer
+     * @param object $refSchema
+     * @throws UnresolvableJsonPointerException when json schema file is found but reference can not be resolved
+     * @return object
+     */
+    private function getRefSchema(JsonPointer $jsonPointer, $refSchema)
+    {
+        foreach ($jsonPointer->getPropertyPaths() as $path) {
+            if (is_object($refSchema) && property_exists($refSchema, $path)) {
+                $refSchema = $refSchema->{$path};
+            } elseif (is_array($refSchema) && array_key_exists($path, $refSchema)) {
+                $refSchema = $refSchema[$path];
+            } else {
+                throw new UnresolvableJsonPointerException(sprintf(
+                    'File: %s is found, but could not resolve fragment: %s',
+                    $jsonPointer->getFilename(),
+                    $jsonPointer->getPropertyPathAsString()
+                ));
+            }
+        }
+
+        return $refSchema;
+    }
+
+    /**
+     * @param object $refSchema
+     * @param object $schema
+     * @param string $fileName
+     * @param array $paths
+     */
+    private function unionSchemas($refSchema, $schema, $fileName, array $paths)
+    {
+        if (property_exists($refSchema, '$ref')) {
+            $jsonPointer = new JsonPointer($this->uriResolver->resolve($refSchema->{'$ref'}, $fileName));
+            $newSchema = $this->resolveCached((string) $jsonPointer, $paths);
+            $this->unionSchemas($newSchema, $refSchema, $fileName, $paths);
+        }
+
+        unset($schema->{'$ref'});
+        if (!$this->hasSubSchemas($schema)) {
+            foreach (get_object_vars($refSchema) as $prop => $value) {
+                $schema->$prop = $value;
+            }
+        } else {
+            $newSchema = new \stdClass();
+            foreach (get_object_vars($schema) as $prop => $value) {
+                $newSchema->$prop = $value;
+                unset($schema->$prop);
+            }
+            $schema->allOf = array($newSchema, $refSchema);
+        }
+    }
+
+    /**
+     * @param object $schema
+     * @return bool
+     */
+    private function hasSubSchemas($schema)
+    {
+        foreach (array_keys(get_object_vars($schema)) as $propertyName) {
+            if (in_array($propertyName, $this->getReservedKeysWhichAreInFactSubSchemas())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getReservedKeysWhichAreInFactSubSchemas()
+    {
+        return array(
+            'additionalItems',
+            'additionalProperties',
+            'extends',
+            'items',
+            'disallow',
+            'extends',
+            'items',
+            'type',
+            'allOf',
+            'anyOf',
+            'oneOf',
+            'dependencies',
+            'patternProperties',
+            'properties'
+        );
+    }
+}

--- a/src/PhpUnit/RequestQueryConstraint.php
+++ b/src/PhpUnit/RequestQueryConstraint.php
@@ -19,6 +19,7 @@ class RequestQueryConstraint extends JsonSchemaConstraint
     {
         $normalizedSchema = new \stdClass();
         $normalizedSchema->required = [];
+        $normalizedSchema->properties = new \stdClass();
         foreach ($queryParameters as $queryParameter) {
             $queryParameter = clone $queryParameter;
 
@@ -36,7 +37,7 @@ class RequestQueryConstraint extends JsonSchemaConstraint
                 unset($queryParameter->required);
             }
 
-            $normalizedSchema->{$normalizedName} = $queryParameter;
+            $normalizedSchema->properties->{$normalizedName} = $queryParameter;
         }
 
         parent::__construct($normalizedSchema, 'request query', $validator);

--- a/src/SchemaManager.php
+++ b/src/SchemaManager.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace FR3D\SwaggerAssertions;
 
-use FR3D\SwaggerAssertions\JsonSchema\Uri\Retrievers\FileGetContentsRetriever;
+use FR3D\SwaggerAssertions\JsonSchema\RefResolver;
 use InvalidArgumentException;
-use JsonSchema\RefResolver;
 use JsonSchema\Uri\UriResolver;
 use JsonSchema\Uri\UriRetriever;
 use Rize\UriTemplate\UriTemplate;
@@ -29,7 +28,7 @@ class SchemaManager
      */
     public static function fromUri(string $definitionUri): self
     {
-        $refResolver = new RefResolver((new UriRetriever())->setUriRetriever(new FileGetContentsRetriever()), new UriResolver());
+        $refResolver = new RefResolver(new UriRetriever(), new UriResolver());
 
         return new self($refResolver->resolve($definitionUri));
     }

--- a/tests/PhpUnit/JsonSchemaConstraintTest.php
+++ b/tests/PhpUnit/JsonSchemaConstraintTest.php
@@ -79,7 +79,7 @@ JSON;
             self::assertEquals(
                 <<<'EOF'
 Failed asserting that [{"id":123456789}] is a valid context.
-[name] The property name is required
+[[0].name] The property name is required
 
 EOF
                 ,

--- a/tests/PhpUnit/Psr7AssertsTraitTest.php
+++ b/tests/PhpUnit/Psr7AssertsTraitTest.php
@@ -84,7 +84,7 @@ JSON;
             self::assertEquals(
                 <<<'EOF'
 Failed asserting that [{"id":123456789}] is a valid response body.
-[name] The property name is required
+[[0].name] The property name is required
 
 EOF
                 ,

--- a/tests/PhpUnit/SymfonyAssertsTraitTest.php
+++ b/tests/PhpUnit/SymfonyAssertsTraitTest.php
@@ -82,7 +82,7 @@ JSON;
             self::assertEquals(
                 <<<'EOF'
 Failed asserting that [{"id":123456789}] is a valid response body.
-[name] The property name is required
+[[0].name] The property name is required
 
 EOF
                 ,


### PR DESCRIPTION
Requires `justinrainbow/json-schema:^5.0` which is the current version of the library.

Imported the RefResolver from: https://github.com/Maks3w/SwaggerAssertions/pull/18