### PR TITLE
ignore query string parameters when finding path in templates

### DIFF
--- a/src/SchemaManager.php
+++ b/src/SchemaManager.php
@@ -148,6 +148,8 @@ class SchemaManager
      */
     public function findPathInTemplates(string $requestPath, &$path, &$params = []): bool
     {
+        $requestPath = parse_url($requestPath, PHP_URL_PATH);
+
         $uriTemplateManager = new UriTemplate();
         foreach ($this->getPathTemplates() as $template) {
             if (isset($this->definition->basePath)) {

--- a/tests/SchemaManagerTest.php
+++ b/tests/SchemaManagerTest.php
@@ -35,6 +35,9 @@ class SchemaManagerTest extends TestCase
     {
         $dataCases = [
             'integer' => ['/api/pets/1234', '/pets/{id}', ['id' => 1234]],
+            'integer_with_query_parameter' => ['/api/pets/1234?foo=bar', '/pets/{id}', ['id' => 1234]],
+            'integer_with_query_parameters' => ['/api/pets/1234?foo=bar&abc=xyz', '/pets/{id}', ['id' => 1234]],
+            'none_with_query_parameter' => ['/api/pets?hello=world', '/pets', []],
         ];
 
         $rfc3986AllowedPathCharacters = [


### PR DESCRIPTION
`\FR3D\SwaggerAssertions\SchemaManager::findPathInTemplates` fails if request path variable contains query string / query parameters although the request itself is correct and matches template.