### PR TITLE
Allow PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "license": "BSD-2-Clause",
     "homepage": "https://github.com/Maks3w/SwaggerAssertions",
     "require": {
-        "php": ">= 7.2",
+        "php": ">= 7.2 || >= 8.0",
         "ext-json": "*",
         "justinrainbow/json-schema": "^5",
         "laminas/laminas-http": "^2.11",


### PR DESCRIPTION
Now that laminas-validator 2.14 has been released, it works on PHP 8 :)